### PR TITLE
Bugfix/simple query string

### DIFF
--- a/app/frontend/javascripts/classes/ConditionValueEditorTextField.js
+++ b/app/frontend/javascripts/classes/ConditionValueEditorTextField.js
@@ -5,13 +5,12 @@ import { API_URL } from '../global.js';
 
 export default class ConditionValueEditorTextField extends ConditionValueEditor {
   /**
-   * @param {Object} valuesView - ConditionType Object?(_conditionView, _editors _okButton, _sections)
-   * @param {String} conditionType - "gene" or "disease"?
+   * @param {Object} valuesView - ConditionValues Object(_conditionView, _editors _okButton, _sections)
+   * @param {String} conditionType - "gene" or "disease" or "variant"
    */
 
   constructor(valuesView, conditionType) {
     super(valuesView, conditionType);
-    this._conditionType = conditionType;
 
     // HTML
     this._createElement(

--- a/app/frontend/javascripts/classes/SearchFieldView.js
+++ b/app/frontend/javascripts/classes/SearchFieldView.js
@@ -1,4 +1,3 @@
-import { API_URL } from '../global.js';
 import { CONDITION_TYPE } from '../definition.js';
 
 const NUMBER_OF_SUGGESTS = 10; // TODO: Config
@@ -16,9 +15,9 @@ const KEY_INCREMENT = {
 
 export default class SearchFieldView {
   /**
-   * @param {Object} _delegate - SimpleSearchView Object ?
-   * @param {Element} _elm - SimpleSearchView Element
-   * @param {String} _placeholder - placeholder for gene, disease
+   * @param {Object} _delegate - SimpleSearchView or ConditionValueEditorTextField Object
+   * @param {Element} _elm - Parent element of the search-field-view
+   * @param {String} _placeholder
    * @param {Array} _suggestDictionaries - ['gene', 'disease']
    * @param {URL} _queryURL - API
    * @param {String | Undefined} _conditionType - 'gene' or 'disease' or undefined
@@ -28,7 +27,7 @@ export default class SearchFieldView {
     _elm,
     _placeholder,
     _suggestDictionaries,
-    _queryURL = `${API_URL}/suggest?term=`,
+    _queryURL,
     _conditionType
   ) {
     this._delegate = _delegate;

--- a/app/frontend/javascripts/classes/SimpleSearchView.js
+++ b/app/frontend/javascripts/classes/SimpleSearchView.js
@@ -1,5 +1,6 @@
 import StoreManager from './StoreManager.js';
 import SearchFieldView from './SearchFieldView.js';
+import { API_URL } from '../global.js';
 
 const EXAMPLES = (() => {
   switch (TOGOVAR_FRONTEND_REFERENCE) {
@@ -7,71 +8,71 @@ const EXAMPLES = (() => {
       return [
         {
           key: 'Disease',
-          value: 'Breast-ovarian cancer, familial 2'
+          value: 'Breast-ovarian cancer, familial 2',
         },
         {
           key: 'Gene',
-          value: 'ALDH2'
+          value: 'ALDH2',
         },
         {
           key: 'refSNP',
-          value: 'rs114202595'
+          value: 'rs114202595',
         },
         {
           key: 'TogoVar',
-          value: 'tgv421843'
+          value: 'tgv421843',
         },
         {
           key: 'Position(GRCh37/hg19)',
-          value: '16:48258198'
+          value: '16:48258198',
         },
         {
           key: 'Region(GRCh37/hg19)',
-          value: '10:73270743-73376976'
+          value: '10:73270743-73376976',
         },
         {
           key: 'HGVSc',
-          value: 'NM_000690:c.1510G>A'
+          value: 'NM_000690:c.1510G>A',
         },
         {
           key: 'HGVSp',
-          value: 'ALDH2:p.Glu504Lys'
-        }
+          value: 'ALDH2:p.Glu504Lys',
+        },
       ];
     case 'GRCh38':
       return [
         {
           key: 'Disease',
-          value: 'Breast-ovarian cancer, familial 2'
+          value: 'Breast-ovarian cancer, familial 2',
         },
         {
           key: 'Gene',
-          value: 'ALDH2'
+          value: 'ALDH2',
         },
         {
           key: 'refSNP',
-          value: 'rs114202595'
+          value: 'rs114202595',
         },
         {
           key: 'TogoVar',
-          value: 'tgv421843'
+          value: 'tgv421843',
         },
         {
           key: 'Position(GRCh38)',
-          value: '16:48224287'
+          value: '16:48224287',
         },
         {
           key: 'Region(GRCh38)',
-          value: '10:71510986-71617219'
+          value: '10:71510986-71617219',
         },
         {
           key: 'HGVSc',
-          value: 'NM_000690:c.1510G>A'
+          value: 'NM_000690:c.1510G>A',
         },
         {
           key: 'HGVSp',
-          value: 'ALDH2:p.Glu504Lys'
-        }
+          value: 'ALDH2:p.Glu504Lys',
+        },
       ];
     default:
       return [];
@@ -85,7 +86,8 @@ export default class SimpleSearchView {
       this,
       elm,
       'Search for disease or gene symbol or rs...',
-      ['gene', 'disease']
+      ['gene', 'disease'],
+      `${API_URL}/suggest?term=`
     );
 
     // events
@@ -110,8 +112,9 @@ export default class SimpleSearchView {
     });
   }
 
-  search(value) {
-    StoreManager.setSimpleSearchCondition('term', value);
+  search() {
+    const label = this._searchFieldView.label;
+    StoreManager.setSimpleSearchCondition('term', label);
   }
 
   simpleSearchConditions(conditions) {

--- a/app/frontend/javascripts/classes/SimpleSearchView.js
+++ b/app/frontend/javascripts/classes/SimpleSearchView.js
@@ -113,8 +113,7 @@ export default class SimpleSearchView {
   }
 
   search() {
-    const label = this._searchFieldView.label;
-    StoreManager.setSimpleSearchCondition('term', label);
+    StoreManager.setSimpleSearchCondition('term', this._searchFieldView.label);
   }
 
   simpleSearchConditions(conditions) {

--- a/app/frontend/javascripts/classes/StoreManagerMixin.js
+++ b/app/frontend/javascripts/classes/StoreManagerMixin.js
@@ -194,9 +194,7 @@ export const mixin = {
     window.history.pushState(
       this._URIParameters,
       '',
-      `${window.location.origin}${window.location.pathname}?${$.param(
-        this._URIParameters
-      )}`
+      `${window.location.origin}${window.location.pathname}?mode=advanced`
     );
   },
 


### PR DESCRIPTION
query stringの反映されない問題について解決しました。
以下の変更を行いましたのでご確認をお願いします。

- 原因は`SimpleSearchView.js`のsearchメソッドでvalueを受け取ることができなかったためだと思われます。
valueを引数で受け取るのではなく、`this._searchFieldView.label`で直接書きました。

- `StoreManagerMixin.js`
    jQueryの記述をJavaScriptへ変更 ※advanced検索はPOSTなのでURLは固定値にしました。
    query文字列の取得をdeparam.jsからquery-stringに変更しました。(VScodeで確認すると打ち消し線が入っていたため、同じようなものを探しました。)

- Javadocの説明の書き換え