### PR TITLE
Bugfix/select row

### DIFF
--- a/app/frontend/javascripts/classes/ResultsView.js
+++ b/app/frontend/javascripts/classes/ResultsView.js
@@ -190,6 +190,14 @@ export default class ResultsView {
       StoreManager.getData('suggesting') === true
     )
       return;
+    if (
+      e.key === 'ArrowUp' ||
+      e.key === 'ArrowDown' ||
+      e.key === 'ArrowLeft' ||
+      e.key === 'ArrowRight'
+    ) {
+      e.preventDefault();
+    }
     switch (e.key) {
       case 'ArrowUp': // ↑
         this.shiftSelectedRow(-1);

--- a/app/frontend/javascripts/classes/ResultsView.js
+++ b/app/frontend/javascripts/classes/ResultsView.js
@@ -185,7 +185,11 @@ export default class ResultsView {
 
   // 上下カーソルタイプで選択行の移動 & ESCで選択解除
   keydown(e) {
-    if (StoreManager.getData('selectedRow') === undefined) return;
+    if (
+      StoreManager.getData('selectedRow') === undefined ||
+      StoreManager.getData('suggesting') === true
+    )
+      return;
     switch (e.key) {
       case 'ArrowUp': // ↑
         this.shiftSelectedRow(-1);

--- a/app/frontend/javascripts/classes/ResultsView.js
+++ b/app/frontend/javascripts/classes/ResultsView.js
@@ -190,14 +190,8 @@ export default class ResultsView {
       StoreManager.getData('suggesting') === true
     )
       return;
-    if (
-      e.key === 'ArrowUp' ||
-      e.key === 'ArrowDown' ||
-      e.key === 'ArrowLeft' ||
-      e.key === 'ArrowRight'
-    ) {
-      e.preventDefault();
-    }
+
+    e.stopImmediatePropagation();
     switch (e.key) {
       case 'ArrowUp': // ↑
         this.shiftSelectedRow(-1);

--- a/app/frontend/javascripts/classes/SearchFieldView.js
+++ b/app/frontend/javascripts/classes/SearchFieldView.js
@@ -1,4 +1,5 @@
 import { CONDITION_TYPE } from '../definition.js';
+import StoreManager from './StoreManager.js';
 
 const NUMBER_OF_SUGGESTS = 10; // TODO: Config
 const SUGGEST_LABELS = {
@@ -35,8 +36,9 @@ export default class SearchFieldView {
     this._suggestDictionaries = _suggestDictionaries;
     this._conditionType = _conditionType;
 
-    this._suggesting = false;
     this._isSimpleSearch = true;
+    this._suggesting = false;
+    StoreManager.setData('suggesting', false);
 
     // make HTML
     _elm.innerHTML = `
@@ -138,12 +140,14 @@ export default class SearchFieldView {
     }
 
     this._suggesting = false;
+    StoreManager.setData('suggesting', false);
     this._suggestView.innerHTML = '';
     this._search();
   }
 
   _suggestHide() {
     this._suggesting = false;
+    StoreManager.setData('suggesting', false);
     this._suggestView.innerHTML = '';
     this.lastValue = '';
   }
@@ -169,6 +173,7 @@ export default class SearchFieldView {
     setTimeout(() => {
       if (this._suggesting) {
         this._suggesting = false;
+        StoreManager.setData('suggesting', false);
         this._suggestView.innerHTML = '';
         this.lastValue = '';
       }
@@ -225,6 +230,7 @@ export default class SearchFieldView {
 
   _createSuggestList(data) {
     this._suggesting = true;
+    StoreManager.setData('suggesting', true);
     this.lastValue = this._field.value;
     this._suggestPosition = { x: -1, y: -1 };
     this._dictionaries = [];
@@ -278,6 +284,7 @@ export default class SearchFieldView {
               this._field.value =
                 e.currentTarget.dataset.alias || e.currentTarget.dataset.value;
               this._suggesting = false;
+              StoreManager.setData('suggesting', false);
               this._suggestView.innerHTML = '';
               this._search();
             });
@@ -318,6 +325,7 @@ export default class SearchFieldView {
           this._field.dataset.value =
             e.target.dataset.value || e.target.parentElement.dataset.value; // text dataset value for query, i.e. "value"
           this._suggesting = false;
+          StoreManager.setData('suggesting', false);
           this._suggestView.innerHTML = '';
           this._search();
         });


### PR DESCRIPTION
Simple searchのResultsの行が選択され、かつsuggestが表示されている場合に、keydownでsuggestとrow選択が同時に動いてしまうbugを修正しました。
`SearchFieldView`に`this._suggesting`のプロパティに合わせて` StoreManager.setData('suggesting', false);`を何度も書いています。StoreManagerに登録する他の方法が思いつかずにこのように変更しました。
ご確認をお願いします。