### PR TITLE
bugfix/editing-cancel-label

### DIFF
--- a/app/frontend/javascripts/classes/ConditionValueEditorTextField.js
+++ b/app/frontend/javascripts/classes/ConditionValueEditorTextField.js
@@ -41,7 +41,7 @@ export default class ConditionValueEditorTextField extends ConditionValueEditor 
   // public methods
 
   keepLastValues() {
-    this._lastValue = this._searchFieldView.value;
+    this._lastValue = this._searchFieldView.label;
   }
 
   restore() {


### PR DESCRIPTION
gene検索で編集をして、キャンセルボタンを押すとgene idがlabelとなって表示される問題を修正しました。
ご確認をお願いします。
