### PR TITLE
Fix/category order

### DIFF
--- a/app/frontend/javascripts/classes/Configuration.js
+++ b/app/frontend/javascripts/classes/Configuration.js
@@ -64,11 +64,7 @@ export default class Configuration {
         // デフォルト値作成
         stored = configure.constant.map(item => {
           const newItem = Object.assign({}, item);
-          if (newItem.id === 'type') {
-            newItem.isUsed = false;
-          } else {
-            newItem.isUsed = true;
-          }
+          newItem.isUsed = newItem.id !== 'type';
           return newItem;
         });
       }

--- a/app/frontend/javascripts/classes/Configuration.js
+++ b/app/frontend/javascripts/classes/Configuration.js
@@ -38,8 +38,8 @@ export default class Configuration {
 
     // コンフィグ開く
     document.querySelector('#GlobalHeader > .menus > .config > .menu-button').addEventListener('click', () => {
-      this.open();
-    });
+        this.open();
+      });
     // コンフィグ閉じる
     this.bg.addEventListener('click', () => {
       this.close();
@@ -64,7 +64,11 @@ export default class Configuration {
         // デフォルト値作成
         stored = configure.constant.map(item => {
           const newItem = Object.assign({}, item);
-          newItem.isUsed = true;
+          if (newItem.id === 'type') {
+            newItem.isUsed = false;
+          } else {
+            newItem.isUsed = true;
+          }
           return newItem;
         });
       }
@@ -72,13 +76,13 @@ export default class Configuration {
       configure.container.innerHTML = stored.map(item => `<li><label><input type="checkbox" value="${item.id}"${item.isUsed ? ' checked' : ''}>${item.label}</label></li>`).join('');
       // input イベント
       configure.container.querySelectorAll('li > label > input').forEach(input => {
-        input.addEventListener('change', e => {
-          const stored = StoreManager.getData(configure.storeKey);
-          const item = stored.find(item => item.id === e.target.value);
-          item.isUsed = e.target.checked;
-          StoreManager.setData(configure.storeKey, stored);
-        })
-      });
+          input.addEventListener('change', e => {
+            const stored = StoreManager.getData(configure.storeKey);
+            const item = stored.find(item => item.id === e.target.value);
+            item.isUsed = e.target.checked;
+            StoreManager.setData(configure.storeKey, stored);
+          })
+        });
 
       // set to store
       StoreManager.setData(configure.storeKey, stored);

--- a/app/frontend/javascripts/classes/ResultsRowView.js
+++ b/app/frontend/javascripts/classes/ResultsRowView.js
@@ -139,7 +139,7 @@ export default class ResultsRowView {
     // AlphaMissense
     this.tdAlphaMissense = this.tr.querySelector('td.alpha_missense');
     this.tdAlphaMissenseFunction =
-    this.tdAlphaMissense.querySelector('.variant-function');
+      this.tdAlphaMissense.querySelector('.variant-function');
     // Clinical significance
     this.tdClinical = this.tr.querySelector('td.clinical_significance');
     this.tdClinicalSign = this.tdClinical.querySelector(
@@ -282,6 +282,52 @@ export default class ResultsRowView {
             }
           }
           break;
+        case 'clinical_significance':
+          {
+            if (result.significance && result.significance.length) {
+              this.tdClinical.dataset.remains = result.significance.length - 1;
+              this.tdClinicalSign.dataset.sign =
+                result.significance[0].interpretations[0];
+              this.tdClinicalAnchor.textContent =
+                result.significance[0].condition;
+              this.tdClinicalAnchor.setAttribute(
+                'href',
+                `/disease/${result.significance[0].medgen}`
+              );
+            } else {
+              this.tdClinical.dataset.remains = 0;
+              this.tdClinicalSign.dataset.sign = '';
+              this.tdClinicalAnchor.textContent = '';
+              this.tdClinicalAnchor.setAttribute('href', '');
+            }
+          }
+          break;
+        case 'alpha_missense':
+          {
+            const alphaMissenses = result.transcripts?.filter((x) =>
+              Number.isFinite(x.alpha_missense)
+            );
+            if (alphaMissenses && alphaMissenses.length > 0) {
+              this.tdAlphaMissense.dataset.remains = alphaMissenses.length - 1;
+              this.tdAlphaMissenseFunction.textContent = result.alphamissense;
+              switch (true) {
+                case result.alphamissense < 0.34:
+                  this.tdAlphaMissenseFunction.dataset.function = 'LB';
+                  break;
+                case result.alphamissense > 0.564:
+                  this.tdAlphaMissenseFunction.dataset.function = 'LP';
+                  break;
+                default:
+                  this.tdAlphaMissenseFunction.dataset.function = 'AMBIGUOUS';
+                  break;
+              }
+            } else {
+              this.tdAlphaMissense.dataset.remains = 0;
+              this.tdAlphaMissenseFunction.textContent = '';
+              this.tdAlphaMissenseFunction.dataset.function = '';
+            }
+          }
+          break;
         case 'sift':
           {
             const sifts = result.transcripts?.filter((x) =>
@@ -325,49 +371,6 @@ export default class ResultsRowView {
               this.tdPolyphen.dataset.remains = 0;
               this.tdPolyphenFunction.textContent = '';
               this.tdPolyphenFunction.dataset.function = '';
-            }
-          }
-          break;
-          case 'alpha_missense':
-            {
-              const alphaMissenses = result.transcripts?.filter((x) =>
-                Number.isFinite(x.alpha_missense)
-              );
-              if (alphaMissenses && alphaMissenses.length > 0) {
-                this.tdAlphaMissense.dataset.remains = alphaMissenses.length - 1;
-                this.tdAlphaMissenseFunction.textContent = result.alphamissense;
-                switch (true) {
-                  case result.alphamissense < 0.34:
-                    this.tdAlphaMissenseFunction.dataset.function = 'LB';
-                    break;
-                  case result.alphamissense > 0.564:
-                    this.tdAlphaMissenseFunction.dataset.function = 'LP';
-                    break;
-                  default:
-                    this.tdAlphaMissenseFunction.dataset.function = 'AMBIGUOUS';
-                    break;
-                }
-              } else {
-                this.tdAlphaMissense.dataset.remains = 0;
-                this.tdAlphaMissenseFunction.textContent = '';
-                this.tdAlphaMissenseFunction.dataset.function = '';
-              }
-            }
-            break;
-        case 'clinical_significance':
-          {
-            if (result.significance && result.significance.length) {
-              this.tdClinical.dataset.remains = result.significance.length - 1;
-              this.tdClinicalSign.dataset.sign =
-                result.significance[0].interpretations[0];
-              this.tdClinicalAnchor.textContent =
-                result.significance[0].condition;
-              this.tdClinicalAnchor.setAttribute('href', `/disease/${result.significance[0].medgen}`);
-            } else {
-              this.tdClinical.dataset.remains = 0;
-              this.tdClinicalSign.dataset.sign = '';
-              this.tdClinicalAnchor.textContent = '';
-              this.tdClinicalAnchor.setAttribute('href', '');
             }
           }
           break;

--- a/app/frontend/javascripts/global.js
+++ b/app/frontend/javascripts/global.js
@@ -27,10 +27,10 @@ export const COLUMNS = [
   { label: 'Gene', id: 'gene' },
   { label: 'Alt frequency', id: 'alt_frequency' },
   { label: 'Consequence', id: 'consequence' },
+  { label: 'Clinical significance', id: 'clinical_significance' },
+  { label: 'AlphaMissense', id: 'alpha_missense' },
   { label: 'SIFT', id: 'sift' },
   { label: 'PolyPhen', id: 'polyphen' },
-  { label: 'AlphaMissense', id: 'alpha_missense' },
-  { label: 'Clinical significance', id: 'clinical_significance' },
 ];
 
 export function strIns(str, idx, val) {

--- a/app/frontend/views/doc/en/help.pug
+++ b/app/frontend/views/doc/en/help.pug
@@ -51,9 +51,9 @@ block content
                 li.item.-question
                   a.link(href='#d5') How do you calculate the Consequence value?
                 li.item.-question
-                  a.link(href='#d6') What are AlphaMissense, SIFT and PolyPhen?
+                  a.link(href='#d6') How do you calculate the value of Clinical significance?
                 li.item.-question
-                  a.link(href='#d7') How do you calculate the value of Clinical significance?
+                  a.link(href='#d7') What are AlphaMissense, SIFT and PolyPhen?
                 li.item.-question
                   a.link(href='#d8') Was a liftover tool used for generating variant data?
             li.category
@@ -196,6 +196,15 @@ block content
                 |  is displayed. If there are multiple transcripts for a single variant, only the most critical
                 | consequence may be displayed.
           #d6.question-answer
+            h4.question How do you calculate the value of Clinical significance?
+            .answer
+              p
+                | The value of
+                |
+                a.hyper-text.-external(target='_blank', href='https://www.ncbi.nlm.nih.gov/clinvar/docs/clinsig/#clinsig_options_scv')
+                  | clinical significance in ClinVar
+                |  is displayed.
+          #d7.question-answer
             h4.question What are AlphaMissense, SIFT and Polyphen?
             .answer
               p
@@ -224,7 +233,6 @@ block content
                   a.hyper-text.-external(target='_blank', href='https://asia.ensembl.org/info/docs/tools/vep/script/vep_plugins.html#alphamissense') AlphaMissense in VEP Plugins
                   |
                   | for details.
-
                 li
                   strong SIFT
                   br
@@ -241,7 +249,6 @@ block content
                   a.hyper-text.-external(target='_blank', href='https://asia.ensembl.org/info/genome/variation/prediction/protein_function.html#sift') SIFT in Pathogenicity prediction of Ensembl Variation
                   |
                   | for details.
-
                 li
                   strong PolyPhen
                   br
@@ -264,16 +271,6 @@ block content
                   a.hyper-text.-external(target='_blank', href='https://asia.ensembl.org/info/genome/variation/prediction/protein_function.html#polyphen') Polyphen in Pathogenicity prediction of Ensembl Variation
                   |
                   | for details.
-
-          #d7.question-answer
-            h4.question How do you calculate the value of Clinical significance?
-            .answer
-              p
-                | The value of
-                |
-                a.hyper-text.-external(target='_blank', href='https://www.ncbi.nlm.nih.gov/clinvar/docs/clinsig/#clinsig_options_scv')
-                  | clinical significance in ClinVar
-                |  is displayed.
           #d8.question-answer
             h4.question Was a liftover tool used for generating variant data?
             .answer

--- a/app/frontend/views/doc/en/help.pug
+++ b/app/frontend/views/doc/en/help.pug
@@ -51,7 +51,7 @@ block content
                 li.item.-question
                   a.link(href='#d5') How do you calculate the Consequence value?
                 li.item.-question
-                  a.link(href='#d6') What are SIFT, PolyPhen and AlphaMissense?
+                  a.link(href='#d6') What are AlphaMissense, SIFT and PolyPhen?
                 li.item.-question
                   a.link(href='#d7') How do you calculate the value of Clinical significance?
                 li.item.-question
@@ -196,16 +196,35 @@ block content
                 |  is displayed. If there are multiple transcripts for a single variant, only the most critical
                 | consequence may be displayed.
           #d6.question-answer
-            h4.question What are SIFT, Polyphen and AlphaMissense?
+            h4.question What are AlphaMissense, SIFT and Polyphen?
             .answer
               p
-                | SIFT, PolyPhen, and AlphaMissense predict the impact of variants on protein function when an amino acid sequence is altered.
+                | AlphaMissense, SIFT and PolyPhen predict the impact of variants on protein function when an amino acid sequence is altered.
                 | These programs were performed using
                 |
                 a.hyper-text.-external(target='_blank', href='https://asia.ensembl.org/info/genome/variation/prediction/protein_function.html')
                   | Variant Effect Predictor (VEP)
                 | . The icons below represent the threshold scores used for qualitative predictions.
               ul.unordered-list._margin-bottom._align-left
+                li
+                  strong AlphaMissense
+                  br
+                  div
+                    .variant-function._width_5em._align-center(data-function='LP') &gt; 0.564
+                    span._margin-left Likely pathogenic
+                  div
+                    .variant-function._width_5em._align-center(data-function='AMBIGUOUS') &ge; 0.340
+                    span._margin-left Ambiguous
+                  div
+                    .variant-function._width_5em._align-center(data-function='LB') &lt; 0.340
+                    span._margin-left Likely benign
+                  span The score thresholds for "Likely pathogenic" and "Likely benign" were chosen to classify pathogenic and benign ClinVar variants with 90% precision, respectively. See
+                    |
+                    |
+                  a.hyper-text.-external(target='_blank', href='https://asia.ensembl.org/info/docs/tools/vep/script/vep_plugins.html#alphamissense') AlphaMissense in VEP Plugins
+                  |
+                  | for details.
+
                 li
                   strong SIFT
                   br
@@ -245,24 +264,6 @@ block content
                   a.hyper-text.-external(target='_blank', href='https://asia.ensembl.org/info/genome/variation/prediction/protein_function.html#polyphen') Polyphen in Pathogenicity prediction of Ensembl Variation
                   |
                   | for details.
-                li
-                  strong AlphaMissense
-                  br
-                  div
-                    .variant-function._width_5em._align-center(data-function='LP') &gt; 0.564
-                    span._margin-left Likely pathogenic
-                  div
-                    .variant-function._width_5em._align-center(data-function='AMBIGUOUS') &ge; 0.340
-                    span._margin-left Ambiguous
-                  div
-                    .variant-function._width_5em._align-center(data-function='LB') &lt; 0.340
-                    span._margin-left Likely benign
-                  span The score thresholds for "Likely pathogenic" and "Likely benign" were chosen to classify pathogenic and benign ClinVar variants with 90% precision, respectively. See
-                    |
-                    |
-                  a.hyper-text.-external(target='_blank', href='https://asia.ensembl.org/info/docs/tools/vep/script/vep_plugins.html#alphamissense') AlphaMissense in VEP Plugins
-                  |
-                  | for details.
 
           #d7.question-answer
             h4.question How do you calculate the value of Clinical significance?
@@ -278,7 +279,7 @@ block content
             .answer
               p
                 | Yes. Some of the GRCh38 datasets have been created by lifting over their GRCh37 datasets.
-                | Please refer to 
+                | Please refer to
                 a.hyper-text.-external(target='_blank', href='https://grch38.togovar.org/doc/datasets')
                   |
                   | the Liftover GRCh37 column in the TogoVar datasets (GRCh38) page
@@ -289,7 +290,7 @@ block content
                 | has been used since the release on November 16, 2023.
                 |
                 a.hyper-text.-external(target='_blank', href='https://crossmap.sourceforge.net/')
-                  | CrossMap 
+                  | CrossMap
                 | was used until the release on July 14, 2023.
         section.section
           h3.sectiontitle About the TogoVar search system

--- a/app/frontend/views/doc/ja/help.pug
+++ b/app/frontend/views/doc/ja/help.pug
@@ -49,9 +49,9 @@ block content
                 li.item.-question
                   a.link(href='#d5') Consequenceの値はどのように計算していますか。
                 li.item.-question
-                  a.link(href='#d6') AlphaMissense、SIFT、PolyPhenとは何ですか。
+                  a.link(href='#d6') Clinical Significanceの値はどのように計算していますか。
                 li.item.-question
-                  a.link(href='#d7') Clinical Significanceの値はどのように計算していますか。
+                  a.link(href='#d7') AlphaMissense、SIFT、PolyPhenとは何ですか。
                 li.item.-question
                   a.link(href='#d8') バリアントデータ作成時にリフトオーバツールを利用しましたか。
             li.category
@@ -154,6 +154,14 @@ block content
                   | Variant Effect Predictor (VEP)のvariant consequence
                 | の値を表示しています。１バリアントに対応するトランスクリプトが複数ある場合は、一番重大なconsequenceのみを表示している場合があります。
           #d6.question-answer
+            h4.question Clinical Significanceの値はどのように計算していますか。
+            .answer
+              p
+                a.hyper-text.-external(target='_blank', href='https://www.ncbi.nlm.nih.gov/clinvar/docs/clinsig/#clinsig_options_scv')
+                  | ClinVarのclinical significance
+                | の値を表示しています。
+
+          #d7.question-answer
             h4.question AlphaMissense、SIFT、PolyPhenとは何ですか。
             .answer
               p
@@ -177,7 +185,6 @@ block content
                   span 「Likely pathogenic（おそらく病原性あり）」と 「Likely benign"（おそらく良性）」のスコアの閾値は、それぞれ病原性および良性のClinVarバリアントを90%の精度で分類できるように選ばれました。詳細は
                   a.hyper-text.-external(target='_blank', href='https://asia.ensembl.org/info/docs/tools/vep/script/vep_plugins.html#alphamissense') AlphaMissense in VEP Plugins
                   | を参照ください。
-
                 li
                   strong SIFT
                   br
@@ -191,7 +198,6 @@ block content
                     | 0.05未満のスコアを持つ置換は「有害 (Deleterious)」と分類され、それ以外のスコアは「容認 (Tolerated)」とされます。詳細は
                   a.hyper-text.-external(target='_blank', href='https://asia.ensembl.org/info/genome/variation/prediction/protein_function.html#sift') SIFT in Pathogenicity prediction of Ensembl Variation
                   | を参照ください。
-
                 li
                   strong PolyPhen
                   br
@@ -211,14 +217,6 @@ block content
                     | FPRが10%以下の場合は「Possible Damaging (有害の可能性あり)」とされ、FPRが10%を超えるバリアントは「良性 (Begign)」と分類されます。詳細は
                   a.hyper-text.-external(target='_blank', href='https://asia.ensembl.org/info/genome/variation/prediction/protein_function.html#polyphen') Polyphen in Pathogenicity prediction of Ensembl Variation
                   | を参照ください。
-
-          #d7.question-answer
-            h4.question Clinical Significanceの値はどのように計算していますか。
-            .answer
-              p
-                a.hyper-text.-external(target='_blank', href='https://www.ncbi.nlm.nih.gov/clinvar/docs/clinsig/#clinsig_options_scv')
-                  | ClinVarのclinical significance
-                | の値を表示しています。
           #d8.question-answer
             h4.question バリアントデータ作成時にリフトオーバツールを利用しましたか。
             .answer

--- a/app/frontend/views/doc/ja/help.pug
+++ b/app/frontend/views/doc/ja/help.pug
@@ -49,7 +49,7 @@ block content
                 li.item.-question
                   a.link(href='#d5') Consequenceの値はどのように計算していますか。
                 li.item.-question
-                  a.link(href='#d6') SIFT、PolyPhen、AlphaMissenseとは何ですか。
+                  a.link(href='#d6') AlphaMissense、SIFT、PolyPhenとは何ですか。
                 li.item.-question
                   a.link(href='#d7') Clinical Significanceの値はどのように計算していますか。
                 li.item.-question
@@ -154,14 +154,30 @@ block content
                   | Variant Effect Predictor (VEP)のvariant consequence
                 | の値を表示しています。１バリアントに対応するトランスクリプトが複数ある場合は、一番重大なconsequenceのみを表示している場合があります。
           #d6.question-answer
-            h4.question SIFT、PolyPhen、AlphaMissenseとは何ですか。
+            h4.question AlphaMissense、SIFT、PolyPhenとは何ですか。
             .answer
               p
-                | SIFT、PolyPhenおよびAlphaMissenseはアミノ酸配列が変更された際のタンパク質の機能への影響を予測します。これらのプログラムは
+                | AlphaMissense、SIFTおよびPolyPhenはアミノ酸配列が変更された際のタンパク質の機能への影響を予測します。これらのプログラムは
                 a.hyper-text.-external(target='_blank', href='https://asia.ensembl.org/info/genome/variation/prediction/protein_function.html')
                   | Variant Effect Predictor (VEP)
                 | を使用して計算しました。以下のアイコンは定性的予測に使用される閾値スコアを表しています。
               ul.unordered-list._margin-bottom._align-left
+                li
+                  strong AlphaMissense
+                  br
+                  div
+                    .variant-function._width_5em._align-center(data-function='LP') &gt; 0.564
+                    span._margin-left Likely pathogenic
+                  div
+                    .variant-function._width_5em._align-center(data-function='AMBIGUOUS') &ge; 0.340
+                    span._margin-left Ambiguous
+                  div
+                    .variant-function._width_5em._align-center(data-function='LB') &lt; 0.340
+                    span._margin-left Likely benign
+                  span 「Likely pathogenic（おそらく病原性あり）」と 「Likely benign"（おそらく良性）」のスコアの閾値は、それぞれ病原性および良性のClinVarバリアントを90%の精度で分類できるように選ばれました。詳細は
+                  a.hyper-text.-external(target='_blank', href='https://asia.ensembl.org/info/docs/tools/vep/script/vep_plugins.html#alphamissense') AlphaMissense in VEP Plugins
+                  | を参照ください。
+
                 li
                   strong SIFT
                   br
@@ -175,6 +191,7 @@ block content
                     | 0.05未満のスコアを持つ置換は「有害 (Deleterious)」と分類され、それ以外のスコアは「容認 (Tolerated)」とされます。詳細は
                   a.hyper-text.-external(target='_blank', href='https://asia.ensembl.org/info/genome/variation/prediction/protein_function.html#sift') SIFT in Pathogenicity prediction of Ensembl Variation
                   | を参照ください。
+
                 li
                   strong PolyPhen
                   br
@@ -194,21 +211,7 @@ block content
                     | FPRが10%以下の場合は「Possible Damaging (有害の可能性あり)」とされ、FPRが10%を超えるバリアントは「良性 (Begign)」と分類されます。詳細は
                   a.hyper-text.-external(target='_blank', href='https://asia.ensembl.org/info/genome/variation/prediction/protein_function.html#polyphen') Polyphen in Pathogenicity prediction of Ensembl Variation
                   | を参照ください。
-                li
-                  strong AlphaMissense
-                  br
-                  div
-                    .variant-function._width_5em._align-center(data-function='LP') &gt; 0.564
-                    span._margin-left Likely pathogenic
-                  div
-                    .variant-function._width_5em._align-center(data-function='AMBIGUOUS') &ge; 0.340
-                    span._margin-left Ambiguous
-                  div
-                    .variant-function._width_5em._align-center(data-function='LB') &lt; 0.340
-                    span._margin-left Likely benign
-                  span 「Likely pathogenic（おそらく病原性あり）」と 「Likely benign"（おそらく良性）」のスコアの閾値は、それぞれ病原性および良性のClinVarバリアントを90%の精度で分類できるように選ばれました。詳細は
-                  a.hyper-text.-external(target='_blank', href='https://asia.ensembl.org/info/docs/tools/vep/script/vep_plugins.html#alphamissense') AlphaMissense in VEP Plugins
-                  | を参照ください。
+
           #d7.question-answer
             h4.question Clinical Significanceの値はどのように計算していますか。
             .answer

--- a/app/frontend/views/includes/_search_results_main.pug
+++ b/app/frontend/views/includes/_search_results_main.pug
@@ -90,12 +90,16 @@ main#SearchResultsView.LayoutMainAside
           h3.title Variant type
           .content
             ul.checklist-values
+        section#FilterConsequence.panel-view
+          h3.title Consequence
+          .content
+            ul.checklist-values
         section#FilterClinicalSignificance.panel-view
           h3.title Clinical significance
           .content
             ul.checklist-values
-        section#FilterConsequence.panel-view
-          h3.title Consequence
+        section#FilterAlphaMissense.panel-view
+          h3.title AlphaMissense
           .content
             ul.checklist-values
         section#FilterSIFT.panel-view
@@ -104,9 +108,5 @@ main#SearchResultsView.LayoutMainAside
             ul.checklist-values
         section#FilterPolyPhen.panel-view
           h3.title PolyPhen
-          .content
-            ul.checklist-values
-        section#FilterAlphaMissense.panel-view
-          h3.title AlphaMissense
           .content
             ul.checklist-values


### PR DESCRIPTION
[issue#151](https://github.com/togovar/meeting/issues/151)内の以下の修正を行いました。
- テーブルのth順をConsequence, Clinical significance, AlphaMisssense, SIFT, PolyPhenに変更しました。
- 右サイドバーのpanelの順もテーブルと同じ順にしました。
- Helpページ(en,ja)の順もテーブルと同じ順にしました。
- Configurationの順もテーブルと同じ順にしました。また、Typeをデフォルト非表示(Localhostで初期値false)に変更しました。

**※以下の内容は別ブランチで対応します。**
- テーブル内にアイコンを並べてたものを表示
- Clinical significanceの表示内容の変更。

ご確認をお願いします。